### PR TITLE
Fix id typing in edit page

### DIFF
--- a/src/app/admin/edit/[id]/page.tsx
+++ b/src/app/admin/edit/[id]/page.tsx
@@ -6,7 +6,7 @@ import {supabase} from '@/lib/supabase/client'
 import RequireAuth from '@/components/RequireAuth'
 
 export default function EditInitiativePage() {
-    const {id} = useParams()
+    const { id } = useParams<{ id: string }>()
     const router = useRouter()
 
     const [formData, setFormData] = useState({


### PR DESCRIPTION
## Summary
- narrow the id param type returned by `useParams` in the edit page

## Testing
- `npm run lint`
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_683fe1ee20c8832986f2d72a120dea7d